### PR TITLE
Update Open Food Network DFC API URLs

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,15 +10,15 @@ module.exports = {
   {
     "name": "OFN FR staging",
     "slug": "ofn",
-    "url": "https://staging.coopcircuits.fr/api/dfc-v1.6/enterprises/default/catalog_items.json",
-    "version": "1.6",
+    "url": "https://staging.coopcircuits.fr/api/dfc/enterprises/default/catalog_items.json",
+    "version": "1.8",
     "supporWrite": "true"
   },
   {
     "name": "OFN UK Staging",
     "slug": "ofn-uk",
-    "url": "https://staging.openfoodnetwork.org.uk/api/dfc-v1.6/enterprises/default/catalog_items.json",
-    "version": "1.6",
+    "url": "https://staging.openfoodnetwork.org.uk/api/dfc/enterprises/default/catalog_items.json",
+    "version": "1.8",
     "supporWrite": "true"
   },
   {

--- a/config_prod.js
+++ b/config_prod.js
@@ -13,14 +13,14 @@ module.exports = {
     }, {
       "name": "OFN FR Staging",
       "slug": "ofn-fr",
-      "url": "https://staging.coopcircuits.fr/api/dfc-v1.6/enterprises/default/catalog_items.json",
-      "version":"1.6",
+      "url": "https://staging.coopcircuits.fr/api/dfc/enterprises/default/catalog_items.json",
+      "version":"1.8",
       "supporWrite":"true"
   }, {
       "name": "OFN UK Staging",
       "slug": "ofn-uk",
-      "url": "https://staging.openfoodnetwork.org.uk/api/dfc-v1.6/enterprises/default/catalog_items.json",
-      "version":"1.6",
+      "url": "https://staging.openfoodnetwork.org.uk/api/dfc/enterprises/default/catalog_items.json",
+      "version":"1.8",
       "supporWrite":"true"
     },
     {


### PR DESCRIPTION
We are omitting the version from the URL to reduce maintenance and keep semantic ids stable.